### PR TITLE
Extract cross dependencies

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -19,9 +19,6 @@ depends = [ vim , rust, environment, fzf, direnv]
 "environment.dotfile_folder"="~/dotfiles"
 
 [git]
-# Mergetool is currently configured as vimdiff3
-depends = [ vim ]
-
 [git.files]
 "git/.gitconfig.tmpl"={target= "~/.gitconfig", type = "template"}
 

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,10 +1,9 @@
 [bash]
-# Sets MANPAGER as vim
 # Checks for CARGO_HOME
 # Sets DOTFILES_BASH based on DOTFILES specified in environment
 # Sources ~.fzf.bash if present
 # Hook up to direnv
-depends = [ vim , rust, environment, fzf, direnv]
+depends = [ rust, environment, fzf, direnv]
 
 
 [bash.files]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,4 +1,12 @@
 [bash]
+# Sets MANPAGER as vim
+# Checks for CARGO_HOME
+# Sets DOTFILES_BASH based on DOTFILES specified in environment
+# Sources ~.fzf.bash if present
+# Hook up to direnv
+depends = [ vim , rust, environment, fzf, direnv]
+
+
 [bash.files]
 "bash/.bashrc.tmpl"= { target = "~/.bashrc", type="template"}
 "bash/.inputrc"="~/.inputrc"
@@ -11,6 +19,9 @@
 "environment.dotfile_folder"="~/dotfiles"
 
 [git]
+# Mergetool is currently configured as vimdiff3
+depends = [ vim ]
+
 [git.files]
 "git/.gitconfig.tmpl"={target= "~/.gitconfig", type = "template"}
 
@@ -31,6 +42,9 @@
 "tree-sitter.parser-directory"=""
 
 [vifm]
+# Uses vim as a previewer and opening tool
+depends=[vim]
+
 [vifm.files]
 "vifm/.config/vifm/colors"="~/.config/vifm"
 "vifm/.config/vifm/scripts"="~/.config/vifm"
@@ -49,3 +63,13 @@ depends = ["bash"]
 
 [ssh.variables]
 "ssh.key-files"=[]
+
+[fzf]
+# Currently fzf is installed as a vim package
+# So, to avoid duplication the binary installed via the package
+# is referenced when using on CLI.
+# Hence the dependence on vim
+depends= [ vim ]
+
+[rust]
+[direnv]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,9 +1,8 @@
 [bash]
-# Checks for CARGO_HOME
 # Sets DOTFILES_BASH based on DOTFILES specified in environment
 # Sources ~.fzf.bash if present
 # Hook up to direnv
-depends = [ rust, environment, fzf, direnv]
+depends = [  environment, fzf, direnv]
 
 
 [bash.files]
@@ -68,4 +67,7 @@ depends = ["bash"]
 depends= [ vim ]
 
 [rust]
+[rust.variables]
+"rust.cargo_home"="~/.cargo"
+
 [direnv]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,9 +1,26 @@
-[bash]
-# Sets DOTFILES_BASH based on DOTFILES specified in environment
-# Sources ~.fzf.bash if present
-# Hook up to direnv
-depends = [ "environment" ]
+# Possible packages
 
+[bash]
+depends = [ "environment" ]
+[direnv]
+[environment]
+[fzf]
+# Currently fzf is installed as a vim package
+# So, to avoid duplication the binary installed via the package
+# is referenced when using on CLI.
+depends= [ "vim" ]
+[git]
+[tmux]
+[tree-sitter]
+[vifm]
+# Uses vim as a previewer and opening tool
+depends=[ "vim" ]
+[vim]
+[ssh]
+depends = [ "bash" ]
+[rust]
+
+################################################################################
 
 [bash.files]
 "bash/.bashrc.tmpl"= { target = "~/.bashrc", type="template"}
@@ -11,12 +28,10 @@ depends = [ "environment" ]
 "bash/.profile.tmpl"={ target="~/.profile", type="template"}
 "bash/.bash_history"="~/.bash_history"
 
-[environment]
 [environment.variables]
 # Replace this by future dotter built-in variable (Maybe)
 "environment.dotfile_folder"="~/dotfiles"
 
-[git]
 [git.files]
 "git/.gitconfig.tmpl"={target= "~/.gitconfig", type = "template"}
 
@@ -24,11 +39,9 @@ depends = [ "environment" ]
 "git.name"=""
 "git.email"=""
 
-[tmux]
 [tmux.files]
 "tmux/.tmux.conf"="~/.tmux.conf"
 
-[tree-sitter]
 [tree-sitter.files]
 "tree-sitter/.tree-sitter/bin"={target="~/.tree-sitter/bin",type="symbolic"}
 "tree-sitter/.tree-sitter/config.json.tmpl"={target= "~/.tree-sitter/config.json", type="template"}
@@ -36,22 +49,15 @@ depends = [ "environment" ]
 [tree-sitter.variables]
 "tree-sitter.parser-directory"=""
 
-[vifm]
-# Uses vim as a previewer and opening tool
-depends=[ "vim" ]
 
 [vifm.files]
 "vifm/.config/vifm/colors"="~/.config/vifm"
 "vifm/.config/vifm/scripts"="~/.config/vifm"
 "vifm/.config/vifm/vifmrc"="~/.config/vifm/vifmrc"
 
-[vim]
 [vim.files]
 "vim/.vim"={target= "~/.vim", type="symbolic"}
 "vim/.vimrc"= {target="~/.vimrc", type="symbolic"}
-
-[ssh]
-depends = [ "bash" ]
 
 [ssh.files]
 "bash/helpers/ssh_agent.sh.tmpl"="bash/helpers/ssh_agent.sh"
@@ -59,15 +65,6 @@ depends = [ "bash" ]
 [ssh.variables]
 "ssh.key-files"=[]
 
-[fzf]
-# Currently fzf is installed as a vim package
-# So, to avoid duplication the binary installed via the package
-# is referenced when using on CLI.
-# Hence the dependence on vim
-depends= [ "vim" ]
 
-[rust]
 [rust.variables]
 "rust.cargo_home"="~/.cargo"
-
-[direnv]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -2,7 +2,7 @@
 # Sets DOTFILES_BASH based on DOTFILES specified in environment
 # Sources ~.fzf.bash if present
 # Hook up to direnv
-depends = [  environment, fzf, direnv]
+depends = [ environment ]
 
 
 [bash.files]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -2,7 +2,7 @@
 # Sets DOTFILES_BASH based on DOTFILES specified in environment
 # Sources ~.fzf.bash if present
 # Hook up to direnv
-depends = [ environment ]
+depends = [ "environment" ]
 
 
 [bash.files]
@@ -38,7 +38,7 @@ depends = [ environment ]
 
 [vifm]
 # Uses vim as a previewer and opening tool
-depends=[vim]
+depends=[ "vim" ]
 
 [vifm.files]
 "vifm/.config/vifm/colors"="~/.config/vifm"
@@ -51,7 +51,7 @@ depends=[vim]
 "vim/.vimrc"= {target="~/.vimrc", type="symbolic"}
 
 [ssh]
-depends = ["bash"]
+depends = [ "bash" ]
 
 [ssh.files]
 "bash/helpers/ssh_agent.sh.tmpl"="bash/helpers/ssh_agent.sh"
@@ -64,7 +64,7 @@ depends = ["bash"]
 # So, to avoid duplication the binary installed via the package
 # is referenced when using on CLI.
 # Hence the dependence on vim
-depends= [ vim ]
+depends= [ "vim" ]
 
 [rust]
 [rust.variables]

--- a/bash/.bashrc.tmpl
+++ b/bash/.bashrc.tmpl
@@ -5,8 +5,8 @@ export PATH=$PATH:"$DOTFILES_BASH/scripts"
 
 # If not running interactively, don't do anything
 case $- in
-    *i*) ;;
-      *) return;;
+  *i*) ;;
+  *) return;;
 esac
 
 # don't put duplicate lines or lines starting with space in the history.
@@ -28,14 +28,14 @@ shopt -s checkwinsize
 
 # enable color support of ls and also add handy aliases
 if [ -x /usr/bin/dircolors ]; then
-    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-    alias ls='ls --color=auto'
-    #alias dir='dir --color=auto'
-    #alias vdir='vdir --color=auto'
+  test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+  alias ls='ls --color=auto'
+  #alias dir='dir --color=auto'
+  #alias vdir='vdir --color=auto'
 
-    alias grep='grep --color=auto'
-    alias fgrep='fgrep --color=auto'
-    alias egrep='egrep --color=auto'
+  alias grep='grep --color=auto'
+  alias fgrep='fgrep --color=auto'
+  alias egrep='egrep --color=auto'
 
     # Change the background color for writable and sticky directories
     # Currently green and nord theme are working together to make it unreadable
@@ -57,11 +57,11 @@ if ! shopt -oq posix; then
   elif [ -f /etc/bash_completion ]; then
     . /etc/bash_completion
   fi
-  fi
+fi
 
 
 
-  {{#if dotter.packages.ssh}}
+{{#if dotter.packages.ssh}}
 # Start SSH Agent
 SSH_ENV="$HOME/.ssh/environment"
 if [ -f "$DOTFILES_BASH/helpers/ssh_agent.sh" ] ; then
@@ -71,13 +71,13 @@ if [ -f "$DOTFILES_BASH/helpers/ssh_agent.sh" ] ; then
     ps -ef | grep ${SSH_AGENT_PID} | grep ssh-agent$ > /dev/null || {
       start_ssh_agent;
           add_ssh_keys;
-    }
-else
-  start_ssh_agent;
+        }
+    else
+      start_ssh_agent;
   fi
-  fi
+fi
 
-  {{/if}}
+{{/if}}
 
 #include git branch in prompt
 parse_git_branch(){
@@ -101,8 +101,11 @@ if [ -f ./wsl_enabled.sh ] && source ./wsl_enabled.sh && is_wsl; then
   echo "WSL"
 fi
 
-
+{{#if dotter.packages.direnv}}
 # Hook up direnv to
 eval "$(direnv hook bash)"
+{{/if}}
 
+{{#if dotter.packages.fzf}}
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
+{{/if}}

--- a/bash/.profile.tmpl
+++ b/bash/.profile.tmpl
@@ -40,5 +40,7 @@ if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
 
-# Sourcecargo environment if $CARGO_HOME is set
+# Source cargo environment if $CARGO_HOME is set
+{{#if dotter.packages.rust}}
 FILE="${CARGO_HOME:?}/env" && test -f $FILE && source $FILE
+{{/if}}

--- a/bash/.profile.tmpl
+++ b/bash/.profile.tmpl
@@ -11,12 +11,16 @@
 # Set $DOTFILES environment repo if not already set
 ${DOTFILES:=$HOME/dotfiles}
 export DOTFILES
-export EDITOR=vim
 export PATH=$PATH:~/.local/share/lsp-servers
 
-# Set vim as a pager for man pages, if possible use nvim
+{{#if dotter.packages.vim}}
+# Set vim as a pager for man pages
+export EDITOR=vim
 export MANPAGER="vim -M +MANPAGER -"
-command -v nvim  2> /dev/null && export MANPAGER="nvim +Man!"
+{{/if}}
+
+# NVIM as manpager with this command
+# command -v nvim  2> /dev/null && export MANPAGER="nvim +Man!"
 
 # if running bash
 if [ -n "$BASH_VERSION" ]; then

--- a/git/.gitconfig.tmpl
+++ b/git/.gitconfig.tmpl
@@ -25,7 +25,9 @@
 	fuck-up = reset HEAD --hard
 	ls = ls-files
 [merge]
+{{#if dotter.packages.vim}}
     tool = vimdiff3
+		{{/if}}
 [mergetool "vscode"]
     cmd = code --wait $MERGED
 [diff]

--- a/tree-sitter/completion.bash
+++ b/tree-sitter/completion.bash
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-complete tree-sitter generate -o filenames  -X !*.js;
-complete -W "build-wasm dump-languages generate help highlight init-config parse query tags test web-ui" tree-sitter;


### PR DESCRIPTION
There were several statements that required another installed packages from my  dotfiles.
I collected these dependenies and guarded them by using Handlebar syntax to check if the other packages are selected for that local machine.
The corresponding lines are excluded if the packages are not selected.

The dependences are now all correctly listed at top of `.dotter/global.toml`, including their dependencies.

