### PR TITLE
Setup fzf

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -33,6 +33,9 @@ depends = [ "bash" ]
 # Replace this by future dotter built-in variable (Maybe)
 "environment.dotfile_folder"="$DOTFILES"
 
+[fzf.variables]
+"fzf.home_directory"="$HOME/src/fzf"
+
 [git.files]
 "git/.gitconfig.tmpl"={target= "~/.gitconfig", type = "template"}
 

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -5,10 +5,6 @@ depends = [ "environment" ]
 [direnv]
 [environment]
 [fzf]
-# Currently fzf is installed as a vim package
-# So, to avoid duplication the binary installed via the package
-# is referenced when using on CLI.
-depends= [ "vim" ]
 [git]
 [tmux]
 [tree-sitter]

--- a/.dotter/pre_deploy.sh
+++ b/.dotter/pre_deploy.sh
@@ -2,3 +2,8 @@
 # Open vim, install all plugins, immediately close windows afterwards
 vim -c PlugInstall -c qa
 {{/if}}
+
+{{#if  dotter.packages.fzf }}
+# Source  environment variable for FZF options
+. fzf/fzf_setup.sh
+{{/if}}

--- a/fzf/README.md
+++ b/fzf/README.md
@@ -1,0 +1,7 @@
+[FZF](https://github.com/junegunn/fzf) is configured via environment variables.
+
+There are several examples of how to use the environment variables and how to use FZF in pipelines.
+[Examples_config](https://github.com/junegunn/fzf/wiki)
+
+FZF is now installed in a custom directory, instead of a vim plugin folder. Hence the dependency between VIM and FZF is removed.
+The directory is indicated by $FZF_HOME.

--- a/fzf/fzf_setup.sh
+++ b/fzf/fzf_setup.sh
@@ -1,0 +1,1 @@
+export FZF_DEFAULT_OPTS="--reverse --info=inline --border --height=80% --preview-window=:hidden --bind '?:toggle-preview' --preview 'cat {}' --bind 'ctrl-e:execute(echo {+} | xargs -o vim)' "

--- a/vim/.vimrc.tmpl
+++ b/vim/.vimrc.tmpl
@@ -14,7 +14,7 @@ Plug 'tpope/vim-surround'
 Plug 'wellle/targets.vim'
 Plug 'rhysd/clever-f.vim'
 Plug 'dense-analysis/ale'
-Plug 'junegunn/fzf'
+Plug '{{fzf.home_directory}}'
 Plug 'junegunn/fzf.vim'
 Plug 'machakann/vim-highlightedyank'
 if has('python3')


### PR DESCRIPTION
FZF was installed as a Vim plugin.
This  dependency is now removed as FZF is installed from source outside the Vim ecosystem.
Vim only knows the source directory as such the  main plugin still works but FZF is accessible without installing and running Vim.