### PR TITLE
Add bookmarks

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -28,6 +28,7 @@ depends = [ "bash" ]
 [environment.variables]
 # Replace this by future dotter built-in variable (Maybe)
 "environment.dotfile_folder"="$DOTFILES"
+"environment.bookmarks"=[]
 
 [fzf.variables]
 "fzf.home_directory"="$HOME/src/fzf"

--- a/.dotter/pre_deploy.sh
+++ b/.dotter/pre_deploy.sh
@@ -7,3 +7,14 @@ vim -c PlugInstall -c qa
 # Source  environment variable for FZF options
 . fzf/fzf_setup.sh
 {{/if}}
+
+{{#if  dotter.packages.environment }}
+# Create file containing folder bookmarks
+FILE="$DOTFILES/bookmarks"
+  echo "" >  "$FILE"
+  {{~#each environment.bookmarks}}
+  echo {{this}} >> "$FILE";
+  {{~/each}}
+sed '/^[[:space:]]*$/d' -i "$FILE"
+source "$DOTFILES/fzf/bookmark_searcher.sh"
+{{/if}}

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ local-data.toml
 
 bash/helpers/ssh_agent.sh
 
-folder_shortcuts
+bookmarks

--- a/fzf/bookmark_searcher.sh
+++ b/fzf/bookmark_searcher.sh
@@ -1,0 +1,14 @@
+BOOKMARK_FILE="$DOTFILES/bookmarks"
+
+marks(){
+	if [ -f $BOOKMARK_FILE ]; then
+		local selection=$( cat $BOOKMARK_FILE | fzf  )
+		if [ -n $selection ]; then
+			cd $selection || exit 1
+		else
+			echo " No selection made " && exit 1
+		fi
+	else
+		echo " No bookmark file at $BOOKMARK_FILE " && exit 1
+	fi
+}


### PR DESCRIPTION
A quick script and  hook creating a rudimentary bookmarks system.

There is a dotter variable `environment.bookmarks` containing important directories on the machine. 
These are custom set inside the `local.toml`.

From this, there is a `$DOTFILES/bookmarks` file created, in which these paths are stored.
A function uses fzf to search through this file and cd-ing into the selection.