### PR TITLE
Setup completion

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -2,8 +2,9 @@ vim.cmd([[
 call plug#begin('~/.config/nvim/plugged')
 Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/nvim-cmp', { 'branch' : 'main' }
-Plug 'hrsh7th/cmp-buffer', { 'branch' : 'main' }
 Plug 'hrsh7th/cmp-nvim-lsp', { 'branch' : 'main' }
+Plug 'hrsh7th/cmp-buffer', { 'branch' : 'main' }
+Plug 'hrsh7th/cmp-path', { 'branch' : 'main' }
 Plug 'quangnguyen30192/cmp-nvim-ultisnips', { 'branch' : 'main' }
 Plug 'junegunn/vim-easy-align'
 Plug 'sheerun/vim-polyglot'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,6 +1,7 @@
 vim.cmd([[
 call plug#begin('~/.config/nvim/plugged')
 Plug 'neovim/nvim-lspconfig'
+Plug 'hrsh7th/nvim-cmp', { 'branch' : 'main' }
 Plug 'junegunn/vim-easy-align'
 Plug 'sheerun/vim-polyglot'
 Plug 'tpope/vim-fugitive'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -3,6 +3,7 @@ call plug#begin('~/.config/nvim/plugged')
 Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/nvim-cmp', { 'branch' : 'main' }
 Plug 'hrsh7th/cmp-buffer', { 'branch' : 'main' }
+Plug 'hrsh7th/cmp-nvim-lsp', { 'branch' : 'main' }
 Plug 'junegunn/vim-easy-align'
 Plug 'sheerun/vim-polyglot'
 Plug 'tpope/vim-fugitive'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -4,6 +4,7 @@ Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/nvim-cmp', { 'branch' : 'main' }
 Plug 'hrsh7th/cmp-buffer', { 'branch' : 'main' }
 Plug 'hrsh7th/cmp-nvim-lsp', { 'branch' : 'main' }
+Plug 'quangnguyen30192/cmp-nvim-ultisnips', { 'branch' : 'main' }
 Plug 'junegunn/vim-easy-align'
 Plug 'sheerun/vim-polyglot'
 Plug 'tpope/vim-fugitive'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -2,6 +2,7 @@ vim.cmd([[
 call plug#begin('~/.config/nvim/plugged')
 Plug 'neovim/nvim-lspconfig'
 Plug 'hrsh7th/nvim-cmp', { 'branch' : 'main' }
+Plug 'hrsh7th/cmp-buffer', { 'branch' : 'main' }
 Plug 'junegunn/vim-easy-align'
 Plug 'sheerun/vim-polyglot'
 Plug 'tpope/vim-fugitive'

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -29,8 +29,13 @@ local on_attach = function(client, bufnr)
 
 end
 
+-- Setup completion engine
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
+
 require('lspconfig').rust_analyzer.setup({
   on_attach=on_attach,
+  capabilities=capabilities,
   flags = {
     debounce_text_changes = 200,
   }

--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -22,8 +22,8 @@ function! HandleTab() abort
 	if !col || getline('.')[col - 1] =~ '\s'
 		return "\<Tab>"
 	endif
-	"TODO Trigger  completion here
-	return "\<Tab>"
+	lua require('cmp').complete()
+	return ""
 endfunction
 
 inoremap <silent> <Tab> <C-R>=HandleTab()<CR>

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -7,7 +7,7 @@ local WIDE_HEIGHT = 40
 cmp.setup({
     completion = {
       autocomplete = {
-        types.cmp.TriggerEvent.TextChanged,
+        false
       },
       completeopt = 'menu,noselect',
     },

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -47,5 +47,6 @@ cmp.setup({
       { name = 'buffer'},
       { name = 'nvim_lsp'},
       { name = 'ultisnips'},
+      { name = 'path'},
     },
 })

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -47,5 +47,7 @@ cmp.setup({
       ghost_text = false,
     },
 
-    sources = {},
+    sources = {
+      { name = 'buffer'}
+    },
 })

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -32,10 +32,6 @@ cmp.setup({
       end
     },
 
-    event = {},
-
-    mapping = {},
-
     formatting = {
       deprecated = true,
       format = function(_, vim_item)

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -44,9 +44,9 @@ cmp.setup({
     },
 
     sources = {
-      { name = 'buffer'},
+      { name = 'path'},
       { name = 'nvim_lsp'},
       { name = 'ultisnips'},
-      { name = 'path'},
+      { name = 'buffer'},
     },
 })

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -9,12 +9,7 @@ cmp.setup({
       autocomplete = {
         types.cmp.TriggerEvent.TextChanged,
       },
-      completeopt = 'menu,menuone,noselect',
-      keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]],
-      keyword_length = 1,
-      get_trigger_characters = function(trigger_characters)
-        return trigger_characters
-      end
+      completeopt = 'menu,noselect',
     },
 
     snippet = {
@@ -28,8 +23,6 @@ cmp.setup({
     documentation = {
       border = { '', '', '', ' ', '', '', '', ' ' },
       winhighlight = 'NormalFloat:CmpDocumentation,FloatBorder:CmpDocumentationBorder',
-      maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
-      maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
     },
 
     confirmation = {
@@ -37,19 +30,6 @@ cmp.setup({
       get_commit_characters = function(commit_characters)
         return commit_characters
       end
-    },
-
-    sorting = {
-      priority_weight = 2,
-      comparators = {
-        compare.offset,
-        compare.exact,
-        compare.score,
-        compare.kind,
-        compare.sort_text,
-        compare.length,
-        compare.order,
-      }
     },
 
     event = {},

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -21,7 +21,7 @@ cmp.setup({
     preselect = types.cmp.PreselectMode.Item,
 
     documentation = {
-      border = { '', '', '', ' ', '', '', '', ' ' },
+      border = {  "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
       winhighlight = 'NormalFloat:CmpDocumentation,FloatBorder:CmpDocumentationBorder',
     },
 

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -13,8 +13,8 @@ cmp.setup({
     },
 
     snippet = {
-      expand = function()
-        error('snippet engine is not configured.')
+      expand = function(args)
+        vim.fn['UltiSnips#Anon'](args.body)
       end,
     },
 
@@ -50,5 +50,6 @@ cmp.setup({
     sources = {
       { name = 'buffer'},
       { name = 'nvim_lsp'},
+      { name = 'ultisnips'},
     },
 })

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -48,6 +48,7 @@ cmp.setup({
     },
 
     sources = {
-      { name = 'buffer'}
+      { name = 'buffer'},
+      { name = 'nvim_lsp'},
     },
 })

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -1,0 +1,73 @@
+local compare = require('cmp.config.compare')
+local types = require('cmp.types')
+
+local WIDE_HEIGHT = 40
+
+---@return cmp.ConfigSchema
+return function()
+  return {
+    completion = {
+      autocomplete = {
+        types.cmp.TriggerEvent.TextChanged,
+      },
+      completeopt = 'menu,menuone,noselect',
+      keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]],
+      keyword_length = 1,
+      get_trigger_characters = function(trigger_characters)
+        return trigger_characters
+      end
+    },
+
+    snippet = {
+      expand = function()
+        error('snippet engine is not configured.')
+      end,
+    },
+
+    preselect = types.cmp.PreselectMode.Item,
+
+    documentation = {
+      border = { '', '', '', ' ', '', '', '', ' ' },
+      winhighlight = 'NormalFloat:CmpDocumentation,FloatBorder:CmpDocumentationBorder',
+      maxwidth = math.floor((WIDE_HEIGHT * 2) * (vim.o.columns / (WIDE_HEIGHT * 2 * 16 / 9))),
+      maxheight = math.floor(WIDE_HEIGHT * (WIDE_HEIGHT / vim.o.lines)),
+    },
+
+    confirmation = {
+      default_behavior = types.cmp.ConfirmBehavior.Insert,
+      get_commit_characters = function(commit_characters)
+        return commit_characters
+      end
+    },
+
+    sorting = {
+      priority_weight = 2,
+      comparators = {
+        compare.offset,
+        compare.exact,
+        compare.score,
+        compare.kind,
+        compare.sort_text,
+        compare.length,
+        compare.order,
+      }
+    },
+
+    event = {},
+
+    mapping = {},
+
+    formatting = {
+      deprecated = true,
+      format = function(_, vim_item)
+        return vim_item
+      end
+    },
+
+    experimental = {
+      ghost_text = false,
+    },
+
+    sources = {},
+  }
+end

--- a/nvim/plugin/nvim-cmp.lua
+++ b/nvim/plugin/nvim-cmp.lua
@@ -1,11 +1,10 @@
+local cmp = require('cmp')
 local compare = require('cmp.config.compare')
 local types = require('cmp.types')
 
 local WIDE_HEIGHT = 40
 
----@return cmp.ConfigSchema
-return function()
-  return {
+cmp.setup({
     completion = {
       autocomplete = {
         types.cmp.TriggerEvent.TextChanged,
@@ -69,5 +68,4 @@ return function()
     },
 
     sources = {},
-  }
-end
+})


### PR DESCRIPTION
In order to make  full use  of the built-in lsp, there should be a completion engine better than the vim omni-function.

I integrated one, namely [nvim-cmp](https://github.com/hrsh7th/nvim-cmp). It is now setup for use, including buffer, path,lsp and snippet completion.

All completion is  triggered via the`<TAB>`  key, including snipppet expansion.