### PR TITLE
Add Volta for JS-Toolchains management

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -11,6 +11,7 @@ depends = [ "environment" ]
 [tmux]
 [tree-sitter]
 [vim]
+[volta]
 depends=[ "environment" ]
 [ssh]
 depends = [ "bash" ]
@@ -74,3 +75,6 @@ depends = [ "bash" ]
 [rust.variables]
 "rust.cargo_home"="~/.cargo"
 "rust.rustup_home"="~/.rustup"
+
+[volta.variables]
+"volta.home"="~/.config/volta"

--- a/bash/.profile.tmpl
+++ b/bash/.profile.tmpl
@@ -48,3 +48,8 @@ export RUSTUP_HOME={{rust.rustup_home}}
 export CARGO_HOME={{rust.cargo_home}}
 FILE="${CARGO_HOME}/env" && test -f $FILE && source $FILE
 {{/if}}
+
+{{#if dotter.packages.volta}}
+export VOLTA_HOME={{volta.home}}
+export PATH="$VOLTA_HOME/bin:$PATH"
+{{/if}}


### PR DESCRIPTION
Several LSP-server are relying on Node.JS, as they are/were once VS Code extensions.
I installed Node a few times already but never was satisfied as I hardly use it ever.

Now I installed it with Volta, excited to see were this attempt goes...